### PR TITLE
feat: notebook example for batch predictions in cofolding

### DIFF
--- a/notebooks/Batch_structure_prediction.ipynb
+++ b/notebooks/Batch_structure_prediction.ipynb
@@ -1,0 +1,280 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Performing Batch Cofolding Structure Predictions\n",
+    "\n",
+    "This section provides an example of submitting a batch request to predict the cofolding of up to five molecules with a common receptor protein. The workflow applies to both Chai1 and Boltz2 models, each supporting their respective constraints and user-defined settings."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Before running this notebook, please ensure you:\n",
+    "\n",
+    "1. Are logged in by running `dm login EMAIL` in the terminal\n",
+    "2. Have a Token registered and saved on the file\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install deepmirror"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!dm login <YOUREMAIL>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "\n",
+    "import deepmirror.api as api"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Define some helper functions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def submit_cofold(chains: list[dict], user_settings: dict) -> str:\n",
+    "    response = api.structure_prediction(chains, user_settings)\n",
+    "    return response[\"task_id\"]\n",
+    "\n",
+    "\n",
+    "def batch_cofold_submission(\n",
+    "    receptor_chains: dict,\n",
+    "    ligand_id: str,\n",
+    "    ligand_smiles: list[str],\n",
+    "    user_settings: dict,\n",
+    ") -> list[str] | None:\n",
+    "    if len(ligand_smiles) > 5:\n",
+    "        print(\n",
+    "            \"Please provide less than 5 ligands for batch structure prediction\"\n",
+    "        )\n",
+    "        return None\n",
+    "    if len(ligand_smiles) == 0:\n",
+    "        print(\n",
+    "            \"Please provide at least one ligand for batch structure prediction\"\n",
+    "        )\n",
+    "        return None\n",
+    "\n",
+    "    receptor_chainIDs = [chain[\"label\"] for chain in receptor_chains]\n",
+    "    if ligand_id in receptor_chainIDs:\n",
+    "        print(\n",
+    "            \"Ligand ID cannot be the same as other chains in receptor. Please provide a unique ID for ligand\"\n",
+    "        )\n",
+    "        return None\n",
+    "\n",
+    "    task_ids = []\n",
+    "    for ligand in ligand_smiles:\n",
+    "        chains = receptor_chains + [\n",
+    "            {\n",
+    "                \"label\": ligand_id,\n",
+    "                \"value\": ligand,\n",
+    "                \"type\": \"ligand\",\n",
+    "            }\n",
+    "        ]\n",
+    "        task_ids.append(submit_cofold(chains, user_settings))\n",
+    "    return task_ids\n",
+    "\n",
+    "\n",
+    "def check_status(task_ids: list[str]) -> None:\n",
+    "    is_finished = [False] * len(task_ids)\n",
+    "    while not all(is_finished):\n",
+    "        for idx, task_id in enumerate(task_ids):\n",
+    "            response = api.get_structure_prediction(task_id)\n",
+    "            status = response[\"status\"]\n",
+    "            if status == \"completed\":\n",
+    "                is_finished[idx] = True\n",
+    "                print(f\"Task ID: {task_id} - Current status: {status}\")\n",
+    "            else:\n",
+    "                print(\n",
+    "                    f\"Task ID: {task_id} - Current status: {status} - Waiting 2 min for completion...\"\n",
+    "                )\n",
+    "        time.sleep(120)\n",
+    "\n",
+    "\n",
+    "def download_results(task_ids: list[str]) -> None:\n",
+    "    for task_id in task_ids:\n",
+    "        with open(f\"result-{task_id}.zip\", \"wb\") as f:\n",
+    "            f.write(api.download_structure_prediction(task_id))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Describe the receptor Protein (may include protein chains, RNA/DNA and Ions)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "receptor_chains = [\n",
+    "    {\n",
+    "        \"label\": \"A\",\n",
+    "        \"value\": \"MTEYKLVVVGADGVGKSALTIQLIQNHFVDEYDPTIEDSYRKQVVIDGETCLLDILDTAGQEEYSAMRDQYMRTGEGFLCVFAINNTKSFEDIHHYREQIKRVKDSEDVPMVLVGNKCDLPSRTVDTKQAQDLARSYGIPFIETSAKTRQGVDDAFYTLVREIRKHKEK\",\n",
+    "        \"type\": \"protein\",\n",
+    "    }\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Add constraints -- Chai or Boltz"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "constraint_1 = {\n",
+    "    \"chainA\": \"A\",\n",
+    "    \"res_idxA\": \"F28\",\n",
+    "    \"chainB\": \"A\",\n",
+    "    \"res_idxB\": \"Q99\",\n",
+    "    \"connection_type\": \"contact\",\n",
+    "    \"confidence\": 1.0,\n",
+    "    \"min_distance_angstrom\": 3.0,\n",
+    "    \"max_distance_angstrom\": 5.0,\n",
+    "    \"comment\": \"Inter Protein Chain Contact\",\n",
+    "    \"restraint_id\": \"restraint_0\",\n",
+    "}\n",
+    "\n",
+    "constraint_2 = {\n",
+    "    \"chainA\": \"B\",\n",
+    "    \"res_idxA\": \"\",\n",
+    "    \"chainB\": \"A\",\n",
+    "    \"res_idxB\": \"D57\",\n",
+    "    \"connection_type\": \"pocket\",\n",
+    "    \"confidence\": 1.0,\n",
+    "    \"min_distance_angstrom\": 4,\n",
+    "    \"max_distance_angstrom\": 5,\n",
+    "    \"comment\": \"Protein - Small Molecule Pocket Interaction\",\n",
+    "    \"restraint_id\": \"restraint_1\",\n",
+    "}\n",
+    "\n",
+    "constraints = [constraint_1, constraint_2]\n",
+    "user_settings = {\"constraints\": constraints, \"model\": \"chai\"}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### List all the molecules to cofold using their smiles (less than 5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ligand_smiles = [\n",
+    "    \"C1N(C2OC(COP(OP(O)(O)=O)(O)=O)C(O)C2O)C2N=C(N)NC(=O)C=2N=1\",\n",
+    "    \"C1N(C2OC(CC3N(OC)CCC3)C(O)C2O)C2N=C(N)NC(=O)C=2N=1\",\n",
+    "    \"C1N(C2OCCC2OC)C2C=CC=CC=2N=1\",\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Submit their structure prediction requests"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "submission_task_ids = batch_cofold_submission(\n",
+    "    receptor_chains, \"B\", ligand_smiles, user_settings\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"Task IDs of submitted requests: \", submission_task_ids)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Check Status of submissions and download results as zipped files"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "check_status(submission_task_ids)\n",
+    "\n",
+    "download_results(submission_task_ids)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": ".venv",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
### Changes

Adds an example notebook allowing batch submission of cofolding requests where multiple ligands (limit 5) are being cofolded with the same receptor and user settings.

### Verification
For the example with three ligands, following output tree is generated.
<img width="220" height="332" alt="image" src="https://github.com/user-attachments/assets/5d78e7c2-4254-41c2-b29e-12c78d0994fc" />

<img width="339" height="60" alt="image" src="https://github.com/user-attachments/assets/d6c51b32-9dca-42f9-bc79-ce2606e2df5f" />

